### PR TITLE
[codex] add issue templates and roadmap

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,95 @@
+name: Bug report
+description: Report a provider bug, regression, or unexpected behavior
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting this. Please share enough detail for us to reproduce the problem safely.
+
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: Short description of the problem
+      placeholder: healthchecks_check update fails when channels are reordered
+    validations:
+      required: true
+
+  - type: textarea
+    id: terraform_config
+    attributes:
+      label: Terraform configuration
+      description: Minimal configuration needed to reproduce the bug
+      render: hcl
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed_behavior
+    attributes:
+      label: Actual behavior
+      description: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or error output
+      description: Paste Terraform/provider errors here. Remove secrets before submitting.
+      render: text
+
+  - type: input
+    id: provider_version
+    attributes:
+      label: Provider version
+      placeholder: v0.1.0
+    validations:
+      required: true
+
+  - type: input
+    id: terraform_version
+    attributes:
+      label: Terraform version
+      placeholder: 1.14.9
+    validations:
+      required: true
+
+  - type: input
+    id: healthchecks_version
+    attributes:
+      label: Healthchecks version
+      description: Upstream or self-hosted version/commit if known
+      placeholder: v4.1.1 or commit SHA
+
+  - type: dropdown
+    id: deployment_type
+    attributes:
+      label: Healthchecks deployment type
+      options:
+        - Self-hosted
+        - healthchecks.io
+        - Other
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I removed passwords, API keys, cookies, CSRF tokens, and session identifiers from this report
+          required: true
+        - label: I searched existing issues before opening this report
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Local testing guide
+    url: https://github.com/ehsanmsb/terraform-provider-healthchecks/blob/main/docs/local-testing.md
+    about: Start here for local Healthchecks and Terraform smoke-test setup
+  - name: Provider docs
+    url: https://github.com/ehsanmsb/terraform-provider-healthchecks/tree/main/docs
+    about: Check the provider and resource documentation before opening a question

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,66 @@
+name: Feature request
+description: Propose a new resource, data source, auth mode, or provider capability
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea. Please describe the user need and, if possible, how it maps to Healthchecks behavior or APIs.
+
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      placeholder: add direct project API key authentication
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What user workflow is blocked or inefficient today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the ideal provider/resource/data source/configuration behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: healthchecks_mapping
+    attributes:
+      label: Healthchecks API/UI mapping
+      description: Link or describe the relevant Healthchecks endpoint, view, form, or workflow if known
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Provider authentication
+        - Project resource
+        - Check resource
+        - Integration resource
+        - Project member resource
+        - Data sources
+        - Documentation
+        - Testing / CI
+        - Release / packaging
+        - Other
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues before opening this request
+          required: true

--- a/.github/ISSUE_TEMPLATE/roadmap_item.yml
+++ b/.github/ISSUE_TEMPLATE/roadmap_item.yml
@@ -1,0 +1,50 @@
+name: Roadmap item
+description: Track a planned provider enhancement as a scoped implementation issue
+title: "chore: roadmap item "
+labels:
+  - roadmap
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      placeholder: add read-only project data source
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What is included in this item?
+    validations:
+      required: true
+
+  - type: textarea
+    id: implementation_notes
+    attributes:
+      label: Implementation notes
+      description: Relevant endpoints, forms, models, tests, or edge cases
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: Flat checklist items are great here
+      value: |
+        - [ ]
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Quality
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Check formatting
+        run: |
+          files="$(git ls-files '*.go')"
+          unformatted="$(printf '%s\n' "$files" | xargs gofmt -l)"
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not gofmt-formatted:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Run vet
+        run: go vet ./...
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Build provider
+        run: go build ./...

--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ go test ./...
 go build ./...
 ```
 
+## CI
+
+GitHub Actions runs the `CI` workflow on pull requests and pushes to `main`.
+
+The workflow verifies:
+
+- `gofmt`
+- `go vet`
+- `go test ./...`
+- `go build ./...`
+
+If you protect `main`, a good required status check is:
+
+- `Quality`
+
 ## Releases
 
 This repository uses Semantic Versioning and semantic commits.

--- a/README.md
+++ b/README.md
@@ -87,3 +87,7 @@ go test -v ./...
 - Add first-class project data sources.
 - Improve import behavior so imported projects/checks do not need API-key regeneration.
 - Add acceptance coverage for project key enable/disable behavior.
+
+## Roadmap
+
+See [docs/roadmap.md](docs/roadmap.md) for a more structured list of candidate enhancements that can be turned into GitHub issues.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,42 @@
+# Roadmap
+
+This document collects practical next steps for the Healthchecks Terraform provider. Each item here is a good candidate to split into a standalone GitHub issue.
+
+## High Priority
+
+- Add direct API key authentication to the provider
+  This reduces reliance on session login and makes automation friendlier for existing Healthchecks projects.
+
+- Add data sources
+  Good first targets are project, check, and integration lookup data sources.
+
+- Expand integration support beyond `webhook` and `email`
+  Good next candidates are integrations with straightforward project-scoped form flows such as `ntfy`, `gotify`, `matrix`, `shell`, and `webhook`-adjacent types.
+
+- Improve acceptance coverage
+  Add focused acceptance tests for project key toggles, integration CRUD, check channel attachment, and import behavior.
+
+## Medium Priority
+
+- Add richer import support
+  Imported resources should preserve stable state more cleanly without unnecessary key regeneration or channel reordering churn.
+
+- Add additional project resources
+  Potential targets include project-scoped read-only views and any other project-management workflows that map cleanly to current upstream views.
+
+- Improve integration modularity
+  Split integration implementations by type to make future support additions easier to review and test.
+
+- Add retry and recovery improvements around web-form flows
+  Especially around redirects, key regeneration, and transient local/self-hosted failures.
+
+## Nice To Have
+
+- Add examples for common self-hosted deployment patterns
+  Include examples for direct API key auth once supported and for multi-project usage.
+
+- Improve docs generation and release docs flow
+  Keep `tfplugindocs` output and release documentation tightly aligned with CI.
+
+- Add more observability around provider behavior
+  Better debug logging around authenticated web flows would make troubleshooting easier without leaking secrets.


### PR DESCRIPTION
## Summary

- add GitHub issue templates for bug reports, feature requests, and roadmap items
- add issue template configuration and helpful contact links
- add a provider roadmap document and link it from the README

## Validation

- go test ./...
