### PR TITLE
feat: improve webhook integration configuration

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -17,7 +17,43 @@ plugins:
           release: patch
   - - "@semantic-release/release-notes-generator"
     - preset: conventionalcommits
+      presetConfig:
+        types:
+          - type: feat
+            section: Features
+            hidden: false
+          - type: fix
+            section: Bug Fixes
+            hidden: false
+          - type: perf
+            section: Performance
+            hidden: false
+          - type: refactor
+            section: Refactoring
+            hidden: false
+          - type: docs
+            hidden: true
+          - type: test
+            hidden: true
+          - type: chore
+            hidden: true
+          - type: ci
+            hidden: true
+          - type: build
+            hidden: true
+          - type: style
+            hidden: true
+      writerOpts:
+        commitsSort:
+          - subject
+          - scope
   - - "@semantic-release/exec"
     - publishCmd: |
-        printf '%s\n' "${nextRelease.notes}" > /tmp/release-notes.md
+        cat > /tmp/release-notes.md <<EOF
+        # Release v${nextRelease.version}
+
+        Automated release for terraform-provider-healthchecks.
+
+        ${nextRelease.notes}
+        EOF
         goreleaser release --clean --release-notes /tmp/release-notes.md

--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ This repository uses Semantic Versioning with `semantic-release` and Conventiona
 
 When a branch is merged into `main`, the release workflow analyzes the commits since the previous release, calculates the next version, creates the Git tag automatically, generates release notes, and runs GoReleaser to publish signed provider artifacts.
 
+Release notes are grouped into reader-friendly sections:
+
+- `Features`
+- `Bug Fixes`
+- `Performance`
+- `Refactoring`
+
+Low-signal commit types such as `docs:`, `test:`, `chore:`, `ci:`, and `build:` are hidden from the published release notes unless they also include a breaking change.
+
 The repository includes:
 
 - `.github/workflows/release.yml` for automatic releases on `main`
@@ -101,6 +110,7 @@ Use standard Conventional Commit syntax:
 - `feat: add project data source` → minor release
 - `fix: handle project create redirect` → patch release
 - `perf: reduce retry churn` → patch release
+- `refactor: split webhook config conversion` → no version bump, but shown in release notes
 - `feat!: change import ID format` → major release
 - `BREAKING CHANGE: import format changed` in the commit footer → major release
 

--- a/docs/resources/check.md
+++ b/docs/resources/check.md
@@ -13,13 +13,13 @@ resource "healthchecks_integration" "webhook" {
   type       = "webhook"
   name       = "Checks Webhook"
 
-  config = {
+  webhook = {
     method_down = "POST"
     url_down    = "https://example.com/down"
-    body_down   = "{\"state\":\"down\"}"
+    body_down   = jsonencode({ state = "down" })
     method_up   = "POST"
     url_up      = "https://example.com/up"
-    body_up     = "{\"state\":\"up\"}"
+    body_up     = jsonencode({ state = "up" })
   }
 }
 

--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -55,12 +55,13 @@ resource "healthchecks_integration" "email" {
 
 - `config` (Map of String) Legacy generic integration config map. Still supported for `type = "email"` and webhook backward compatibility, but the `webhook` block is the preferred interface for webhook integrations.
 - `name` (String)
-- `webhook` (Attributes) Structured webhook configuration. Preferred over the legacy `config` map for `type = "webhook"`.
+- `webhook` (Attributes) Structured webhook configuration. Preferred over the legacy `config` map for `type = "webhook"`. (see [below for nested schema](#nestedatt--webhook))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
 
+<a id="nestedatt--webhook"></a>
 ### Nested Schema for `webhook`
 
 Optional:
@@ -73,6 +74,7 @@ Optional:
 - `method_up` (String)
 - `url_down` (String)
 - `url_up` (String)
+
 
 
 ## Import

--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -13,19 +13,21 @@ resource "healthchecks_integration" "webhook" {
   type       = "webhook"
   name       = "Primary Webhook"
 
-  config = {
+  webhook = {
     method_down = "POST"
     url_down    = "https://example.com/down"
-    body_down   = "{\"state\":\"down\"}"
-    headers_down = <<-EOT
-      X-Sample-Header: $NAME has gone down
-    EOT
+    body_down   = jsonencode({ state = "down" })
+    headers_down = {
+      X-Sample-Header = "$NAME has gone down"
+      X-Env           = "production"
+    }
     method_up = "POST"
     url_up    = "https://example.com/up"
-    body_up   = "{\"state\":\"up\"}"
-    headers_up = <<-EOT
-      X-Sample-Header: $NAME has recovered
-    EOT
+    body_up   = jsonencode({ state = "up" })
+    headers_up = {
+      X-Sample-Header = "$NAME has recovered"
+      X-Env           = "production"
+    }
   }
 }
 
@@ -46,17 +48,31 @@ resource "healthchecks_integration" "email" {
 
 ### Required
 
-- `config` (Map of String)
 - `project_id` (String)
 - `type` (String)
 
 ### Optional
 
+- `config` (Map of String) Legacy generic integration config map. Still supported for `type = "email"` and webhook backward compatibility, but the `webhook` block is the preferred interface for webhook integrations.
 - `name` (String)
+- `webhook` (Attributes) Structured webhook configuration. Preferred over the legacy `config` map for `type = "webhook"`.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+### Nested Schema for `webhook`
+
+Optional:
+
+- `body_down` (String)
+- `body_up` (String)
+- `headers_down` (Map of String)
+- `headers_up` (Map of String)
+- `method_down` (String)
+- `method_up` (String)
+- `url_down` (String)
+- `url_up` (String)
 
 
 ## Import
@@ -70,7 +86,8 @@ terraform import healthchecks_integration.webhook 1c580c01-499d-4832-a928-3a407d
 ## Notes
 
 - Use `type = "webhook"` for HTTP callbacks on up/down events.
-- Webhook integrations support the optional top-level `name` attribute.
-- Webhook request headers can be configured with `config.headers_down` and `config.headers_up` using newline-delimited `Header-Name: value` entries.
+- Webhook integrations support the optional top-level `name` attribute and the structured `webhook` block.
+- Webhook request headers can be configured with `webhook.headers_down` and `webhook.headers_up` as maps of header names to values.
+- The legacy `config` map is still accepted for webhook integrations, but the `webhook` block is the preferred interface.
 - Use `type = "email"` with `config.value` set to the destination email address.
 - Integrations become active for a check when their channel ID is referenced in `healthchecks_check.channels`.

--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -17,9 +17,15 @@ resource "healthchecks_integration" "webhook" {
     method_down = "POST"
     url_down    = "https://example.com/down"
     body_down   = "{\"state\":\"down\"}"
-    method_up   = "POST"
-    url_up      = "https://example.com/up"
-    body_up     = "{\"state\":\"up\"}"
+    headers_down = <<-EOT
+      X-Sample-Header: $NAME has gone down
+    EOT
+    method_up = "POST"
+    url_up    = "https://example.com/up"
+    body_up   = "{\"state\":\"up\"}"
+    headers_up = <<-EOT
+      X-Sample-Header: $NAME has recovered
+    EOT
   }
 }
 
@@ -64,5 +70,7 @@ terraform import healthchecks_integration.webhook 1c580c01-499d-4832-a928-3a407d
 ## Notes
 
 - Use `type = "webhook"` for HTTP callbacks on up/down events.
+- Webhook integrations support the optional top-level `name` attribute.
+- Webhook request headers can be configured with `config.headers_down` and `config.headers_up` using newline-delimited `Header-Name: value` entries.
 - Use `type = "email"` with `config.value` set to the destination email address.
 - Integrations become active for a check when their channel ID is referenced in `healthchecks_check.channels`.

--- a/examples/check/main.tf
+++ b/examples/check/main.tf
@@ -7,13 +7,13 @@ resource "healthchecks_integration" "webhook" {
   type       = "webhook"
   name       = "Checks Webhook"
 
-  config = {
+  webhook = {
     method_down = "POST"
     url_down    = "https://example.com/down"
-    body_down   = "{\"state\":\"down\"}"
+    body_down   = jsonencode({ state = "down" })
     method_up   = "POST"
     url_up      = "https://example.com/up"
-    body_up     = "{\"state\":\"up\"}"
+    body_up     = jsonencode({ state = "up" })
   }
 }
 

--- a/examples/check_disable_integration/main.tf
+++ b/examples/check_disable_integration/main.tf
@@ -7,7 +7,7 @@ resource "healthchecks_integration" "webhook" {
   type       = "webhook"
   name       = "Disable Demo Webhook"
 
-  config = {
+  webhook = {
     method_down = "POST"
     url_down    = "https://example.com/down"
     method_up   = "POST"

--- a/examples/complete_project/main.tf
+++ b/examples/complete_project/main.tf
@@ -24,13 +24,13 @@ resource "healthchecks_integration" "webhook" {
   type       = "webhook"
   name       = "project-webhook"
 
-  config = {
+  webhook = {
     method_down = "POST"
     url_down    = "https://example.com/down"
-    body_down   = "{\"status\":\"down\"}"
+    body_down   = jsonencode({ status = "down" })
     method_up   = "POST"
     url_up      = "https://example.com/up"
-    body_up     = "{\"status\":\"up\"}"
+    body_up     = jsonencode({ status = "up" })
   }
 }
 

--- a/examples/integration/main.tf
+++ b/examples/integration/main.tf
@@ -7,19 +7,21 @@ resource "healthchecks_integration" "webhook" {
   type       = "webhook"
   name       = "Primary Webhook"
 
-  config = {
+  webhook = {
     method_down = "POST"
     url_down    = "https://example.com/down"
-    body_down   = "{\"state\":\"down\"}"
-    headers_down = <<-EOT
-      X-Sample-Header: $NAME has gone down
-    EOT
+    body_down   = jsonencode({ state = "down" })
+    headers_down = {
+      X-Sample-Header = "$NAME has gone down"
+      X-Env           = "production"
+    }
     method_up = "POST"
     url_up    = "https://example.com/up"
-    body_up   = "{\"state\":\"up\"}"
-    headers_up = <<-EOT
-      X-Sample-Header: $NAME has recovered
-    EOT
+    body_up   = jsonencode({ state = "up" })
+    headers_up = {
+      X-Sample-Header = "$NAME has recovered"
+      X-Env           = "production"
+    }
   }
 }
 

--- a/examples/integration/main.tf
+++ b/examples/integration/main.tf
@@ -6,13 +6,20 @@ resource "healthchecks_integration" "webhook" {
   project_id = healthchecks_project.example.id
   type       = "webhook"
   name       = "Primary Webhook"
+
   config = {
     method_down = "POST"
     url_down    = "https://example.com/down"
     body_down   = "{\"state\":\"down\"}"
-    method_up   = "POST"
-    url_up      = "https://example.com/up"
-    body_up     = "{\"state\":\"up\"}"
+    headers_down = <<-EOT
+      X-Sample-Header: $NAME has gone down
+    EOT
+    method_up = "POST"
+    url_up    = "https://example.com/up"
+    body_up   = "{\"state\":\"up\"}"
+    headers_up = <<-EOT
+      X-Sample-Header: $NAME has recovered
+    EOT
   }
 }
 

--- a/examples/local_smoke/main.tf
+++ b/examples/local_smoke/main.tf
@@ -63,13 +63,13 @@ resource "healthchecks_integration" "webhook" {
   type       = "webhook"
   name       = "webhook-smoke"
 
-  config = {
+  webhook = {
     method_down = "POST"
     url_down    = "https://example.com/down"
-    body_down   = "{\"status\":\"down\"}"
+    body_down   = jsonencode({ status = "down" })
     method_up   = "POST"
     url_up      = "https://example.com/up"
-    body_up     = "{\"status\":\"up\"}"
+    body_up     = jsonencode({ status = "up" })
   }
 }
 

--- a/examples/project_integrations_smoke/main.tf
+++ b/examples/project_integrations_smoke/main.tf
@@ -21,13 +21,13 @@ resource "healthchecks_integration" "webhook" {
   type       = "webhook"
   name       = "smoke-webhook"
 
-  config = {
+  webhook = {
     method_down = "POST"
     url_down    = "https://example.com/down"
-    body_down   = "{\"state\":\"down\"}"
+    body_down   = jsonencode({ state = "down" })
     method_up   = "POST"
     url_up      = "https://example.com/up"
-    body_up     = "{\"state\":\"up\"}"
+    body_up     = jsonencode({ state = "up" })
   }
 }
 

--- a/examples/resources/healthchecks_check/resource.tf
+++ b/examples/resources/healthchecks_check/resource.tf
@@ -7,13 +7,13 @@ resource "healthchecks_integration" "webhook" {
   type       = "webhook"
   name       = "Checks Webhook"
 
-  config = {
+  webhook = {
     method_down = "POST"
     url_down    = "https://example.com/down"
-    body_down   = "{\"state\":\"down\"}"
+    body_down   = jsonencode({ state = "down" })
     method_up   = "POST"
     url_up      = "https://example.com/up"
-    body_up     = "{\"state\":\"up\"}"
+    body_up     = jsonencode({ state = "up" })
   }
 }
 

--- a/examples/resources/healthchecks_integration/resource.tf
+++ b/examples/resources/healthchecks_integration/resource.tf
@@ -7,19 +7,21 @@ resource "healthchecks_integration" "webhook" {
   type       = "webhook"
   name       = "Primary Webhook"
 
-  config = {
+  webhook = {
     method_down = "POST"
     url_down    = "https://example.com/down"
-    body_down   = "{\"state\":\"down\"}"
-    headers_down = <<-EOT
-      X-Sample-Header: $NAME has gone down
-    EOT
+    body_down   = jsonencode({ state = "down" })
+    headers_down = {
+      X-Sample-Header = "$NAME has gone down"
+      X-Env           = "production"
+    }
     method_up = "POST"
     url_up    = "https://example.com/up"
-    body_up   = "{\"state\":\"up\"}"
-    headers_up = <<-EOT
-      X-Sample-Header: $NAME has recovered
-    EOT
+    body_up   = jsonencode({ state = "up" })
+    headers_up = {
+      X-Sample-Header = "$NAME has recovered"
+      X-Env           = "production"
+    }
   }
 }
 

--- a/examples/resources/healthchecks_integration/resource.tf
+++ b/examples/resources/healthchecks_integration/resource.tf
@@ -11,9 +11,15 @@ resource "healthchecks_integration" "webhook" {
     method_down = "POST"
     url_down    = "https://example.com/down"
     body_down   = "{\"state\":\"down\"}"
-    method_up   = "POST"
-    url_up      = "https://example.com/up"
-    body_up     = "{\"state\":\"up\"}"
+    headers_down = <<-EOT
+      X-Sample-Header: $NAME has gone down
+    EOT
+    method_up = "POST"
+    url_up    = "https://example.com/up"
+    body_up   = "{\"state\":\"up\"}"
+    headers_up = <<-EOT
+      X-Sample-Header: $NAME has recovered
+    EOT
   }
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -615,11 +615,7 @@ func (c *Client) CreateWebhookIntegration(ctx context.Context, in Integration) (
 	if err != nil {
 		return nil, err
 	}
-	values := url.Values{}
-	for k, v := range in.Config {
-		values.Set(k, v)
-	}
-	values.Set("name", in.Name)
+	values := webhookConfigToFormValues(in.Name, in.Config)
 	if _, _, err := c.postForm(ctx, fmt.Sprintf("/projects/%s/add_webhook/", in.ProjectID), values, token); err != nil {
 		return nil, err
 	}
@@ -735,11 +731,7 @@ func (c *Client) UpdateWebhookIntegration(ctx context.Context, in Integration) (
 	if err != nil {
 		return nil, err
 	}
-	values := url.Values{}
-	for k, v := range in.Config {
-		values.Set(k, v)
-	}
-	values.Set("name", in.Name)
+	values := webhookConfigToFormValues(in.Name, in.Config)
 	if _, _, err := c.postForm(ctx, fmt.Sprintf("/integrations/%s/edit/", in.ID), values, token); err != nil {
 		return nil, err
 	}
@@ -1263,6 +1255,15 @@ func emailConfigToFormValues(config map[string]string) url.Values {
 	if parseBoolString(config["up"], true) {
 		values.Set("up", "on")
 	}
+	return values
+}
+
+func webhookConfigToFormValues(name string, config map[string]string) url.Values {
+	values := url.Values{}
+	for key, value := range config {
+		values.Set(key, value)
+	}
+	values.Set("name", name)
 	return values
 }
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -160,6 +160,65 @@ func TestEmailConfigToFormValues(t *testing.T) {
 	}
 }
 
+func TestWebhookConfigToFormValues(t *testing.T) {
+	values := webhookConfigToFormValues("Primary Webhook", map[string]string{
+		"method_down":  "POST",
+		"url_down":     "https://example.com/down",
+		"headers_down": "X-Sample-Header: $NAME has gone down",
+		"method_up":    "POST",
+		"url_up":       "https://example.com/up",
+		"headers_up":   "X-Sample-Header: $NAME has recovered",
+	})
+
+	if values.Get("name") != "Primary Webhook" {
+		t.Fatalf("unexpected name: %q", values.Get("name"))
+	}
+	if values.Get("headers_down") != "X-Sample-Header: $NAME has gone down" {
+		t.Fatalf("unexpected down headers: %q", values.Get("headers_down"))
+	}
+	if values.Get("headers_up") != "X-Sample-Header: $NAME has recovered" {
+		t.Fatalf("unexpected up headers: %q", values.Get("headers_up"))
+	}
+}
+
+func TestGetWebhookIntegrationParsesNameAndHeaders(t *testing.T) {
+	doc := docFromString(t, `
+		<form>
+			<input type="text" name="name" value="Primary Webhook">
+			<select name="method_down"><option value="POST" selected>POST</option></select>
+			<input type="url" name="url_down" value="https://example.com/down">
+			<textarea name="headers_down">X-Sample-Header: $NAME has gone down</textarea>
+			<select name="method_up"><option value="POST" selected>POST</option></select>
+			<input type="url" name="url_up" value="https://example.com/up">
+			<textarea name="headers_up">X-Sample-Header: $NAME has recovered</textarea>
+		</form>
+	`)
+
+	config := map[string]string{}
+	for _, field := range []string{"url_down", "body_down", "headers_down", "url_up", "body_up", "headers_up"} {
+		if value, ok := extractNamedFieldValue(doc, field); ok && strings.TrimSpace(value) != "" {
+			config[field] = value
+		}
+	}
+	if value, ok := extractNamedSelectValue(doc, "method_down"); ok {
+		config["method_down"] = value
+	}
+	if value, ok := extractNamedSelectValue(doc, "method_up"); ok {
+		config["method_up"] = value
+	}
+	name, _ := extractNamedFieldValue(doc, "name")
+
+	if name != "Primary Webhook" {
+		t.Fatalf("unexpected name: %q", name)
+	}
+	if config["headers_down"] != "X-Sample-Header: $NAME has gone down" {
+		t.Fatalf("unexpected down headers: %q", config["headers_down"])
+	}
+	if config["headers_up"] != "X-Sample-Header: $NAME has recovered" {
+		t.Fatalf("unexpected up headers: %q", config["headers_up"])
+	}
+}
+
 func TestParseBoolString(t *testing.T) {
 	cases := []struct {
 		input        string

--- a/internal/resources/integration/resource.go
+++ b/internal/resources/integration/resource.go
@@ -197,7 +197,7 @@ func (r *integrationResource) ImportState(ctx context.Context, req resource.Impo
 
 func mapToStrings(ctx context.Context, m types.Map) (map[string]string, error) {
 	out := map[string]string{}
-	if m.IsNull() {
+	if m.IsNull() || m.IsUnknown() {
 		return out, nil
 	}
 	diags := m.ElementsAs(ctx, &out, false)

--- a/internal/resources/integration/resource.go
+++ b/internal/resources/integration/resource.go
@@ -3,10 +3,12 @@ package integration
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -33,6 +35,18 @@ type model struct {
 	Type      types.String `tfsdk:"type"`
 	Name      types.String `tfsdk:"name"`
 	Config    types.Map    `tfsdk:"config"`
+	Webhook   webhookModel `tfsdk:"webhook"`
+}
+
+type webhookModel struct {
+	MethodDown  types.String `tfsdk:"method_down"`
+	URLDown     types.String `tfsdk:"url_down"`
+	BodyDown    types.String `tfsdk:"body_down"`
+	HeadersDown types.Map    `tfsdk:"headers_down"`
+	MethodUp    types.String `tfsdk:"method_up"`
+	URLUp       types.String `tfsdk:"url_up"`
+	BodyUp      types.String `tfsdk:"body_up"`
+	HeadersUp   types.Map    `tfsdk:"headers_up"`
 }
 
 func (r *integrationResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -47,7 +61,27 @@ func (r *integrationResource) Schema(_ context.Context, _ resource.SchemaRequest
 			"project_id": schema.StringAttribute{Required: true, PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},
 			"type":       schema.StringAttribute{Required: true},
 			"name":       schema.StringAttribute{Optional: true},
-			"config":     schema.MapAttribute{Required: true, ElementType: types.StringType},
+			"config": schema.MapAttribute{
+				Optional:            true,
+				Computed:            true,
+				ElementType:         types.StringType,
+				MarkdownDescription: "Legacy generic integration config map. Still supported for `type = \"email\"` and webhook backward compatibility, but the `webhook` block is the preferred interface for webhook integrations.",
+			},
+			"webhook": schema.SingleNestedAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Structured webhook configuration. Preferred over the legacy `config` map for `type = \"webhook\"`.",
+				Attributes: map[string]schema.Attribute{
+					"method_down":  schema.StringAttribute{Optional: true},
+					"url_down":     schema.StringAttribute{Optional: true},
+					"body_down":    schema.StringAttribute{Optional: true},
+					"headers_down": schema.MapAttribute{Optional: true, ElementType: types.StringType},
+					"method_up":    schema.StringAttribute{Optional: true},
+					"url_up":       schema.StringAttribute{Optional: true},
+					"body_up":      schema.StringAttribute{Optional: true},
+					"headers_up":   schema.MapAttribute{Optional: true, ElementType: types.StringType},
+				},
+			},
 		},
 	}
 }
@@ -65,7 +99,13 @@ func (r *integrationResource) Create(ctx context.Context, req resource.CreateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	cfg, _ := mapToStrings(ctx, plan.Config)
+
+	cfg, diags := configFromModel(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	integration, err := r.createIntegration(ctx, client.Integration{
 		ProjectID: plan.ProjectID.ValueString(),
 		Type:      plan.Type.ValueString(),
@@ -76,6 +116,7 @@ func (r *integrationResource) Create(ctx context.Context, req resource.CreateReq
 		resp.Diagnostics.AddError("Unable to Create Integration", err.Error())
 		return
 	}
+
 	state := plan
 	applyIntegration(&state, integration)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -87,6 +128,7 @@ func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
 	integration, err := r.getIntegration(ctx, state.ProjectID.ValueString(), state.ID.ValueString(), state.Type.ValueString())
 	if err != nil {
 		if errors.Is(err, client.ErrNotFound()) {
@@ -96,6 +138,7 @@ func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest
 		resp.Diagnostics.AddError("Unable to Read Integration", err.Error())
 		return
 	}
+
 	applyIntegration(&state, integration)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -106,7 +149,13 @@ func (r *integrationResource) Update(ctx context.Context, req resource.UpdateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	cfg, _ := mapToStrings(ctx, plan.Config)
+
+	cfg, diags := configFromModel(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	integration, err := r.updateIntegration(ctx, client.Integration{
 		ID:        plan.ID.ValueString(),
 		ProjectID: plan.ProjectID.ValueString(),
@@ -118,6 +167,7 @@ func (r *integrationResource) Update(ctx context.Context, req resource.UpdateReq
 		resp.Diagnostics.AddError("Unable to Update Integration", err.Error())
 		return
 	}
+
 	state := plan
 	applyIntegration(&state, integration)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -157,6 +207,166 @@ func mapToStrings(ctx context.Context, m types.Map) (map[string]string, error) {
 	return out, nil
 }
 
+func webhookHasValues(m webhookModel) bool {
+	for _, v := range []attr.Value{
+		m.MethodDown,
+		m.URLDown,
+		m.BodyDown,
+		m.HeadersDown,
+		m.MethodUp,
+		m.URLUp,
+		m.BodyUp,
+		m.HeadersUp,
+	} {
+		if !v.IsNull() && !v.IsUnknown() {
+			return true
+		}
+	}
+	return false
+}
+
+func configFromModel(ctx context.Context, plan model) (map[string]string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	legacyConfig, err := mapToStrings(ctx, plan.Config)
+	if err != nil {
+		diags.AddError("Invalid Integration Config", err.Error())
+		return nil, diags
+	}
+
+	switch plan.Type.ValueString() {
+	case "webhook":
+		hasWebhook := webhookHasValues(plan.Webhook)
+		hasLegacy := !plan.Config.IsNull() && !plan.Config.IsUnknown()
+
+		if hasWebhook && hasLegacy {
+			diags.AddError(
+				"Conflicting Webhook Configuration",
+				"Use either the structured `webhook` block or the legacy `config` map for `type = \"webhook\"`, but not both.",
+			)
+			return nil, diags
+		}
+		if hasWebhook {
+			webhookConfig, err := webhookToConfig(ctx, plan.Webhook)
+			if err != nil {
+				diags.AddError("Invalid Webhook Configuration", err.Error())
+				return nil, diags
+			}
+			return webhookConfig, diags
+		}
+		if hasLegacy {
+			return legacyConfig, diags
+		}
+
+		diags.AddError(
+			"Missing Webhook Configuration",
+			"Set either the structured `webhook` block or the legacy `config` map when `type = \"webhook\"`.",
+		)
+		return nil, diags
+	case "email":
+		if webhookHasValues(plan.Webhook) {
+			diags.AddError(
+				"Webhook Block Not Allowed",
+				"The `webhook` block can only be used when `type = \"webhook\"`.",
+			)
+			return nil, diags
+		}
+		if plan.Config.IsNull() || plan.Config.IsUnknown() {
+			diags.AddError(
+				"Missing Email Configuration",
+				"Set the `config` map when `type = \"email\"`.",
+			)
+			return nil, diags
+		}
+		return legacyConfig, diags
+	default:
+		return legacyConfig, diags
+	}
+}
+
+func webhookToConfig(ctx context.Context, webhook webhookModel) (map[string]string, error) {
+	config := map[string]string{}
+
+	for key, value := range map[string]types.String{
+		"method_down": webhook.MethodDown,
+		"url_down":    webhook.URLDown,
+		"body_down":   webhook.BodyDown,
+		"method_up":   webhook.MethodUp,
+		"url_up":      webhook.URLUp,
+		"body_up":     webhook.BodyUp,
+	} {
+		if !value.IsNull() && !value.IsUnknown() && strings.TrimSpace(value.ValueString()) != "" {
+			config[key] = value.ValueString()
+		}
+	}
+
+	for key, value := range map[string]types.Map{
+		"headers_down": webhook.HeadersDown,
+		"headers_up":   webhook.HeadersUp,
+	} {
+		headers, err := mapToStrings(ctx, value)
+		if err != nil {
+			return nil, err
+		}
+		if len(headers) == 0 {
+			continue
+		}
+		config[key] = joinHeaderLines(headers)
+	}
+
+	return config, nil
+}
+
+func joinHeaderLines(headers map[string]string) string {
+	keys := make([]string, 0, len(headers))
+	for key := range headers {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	lines := make([]string, 0, len(keys))
+	for _, key := range keys {
+		lines = append(lines, fmt.Sprintf("%s: %s", key, headers[key]))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func parseHeaderLines(value string) map[string]string {
+	headers := map[string]string{}
+	for _, line := range strings.Split(value, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		headers[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+	}
+	return headers
+}
+
+func mapStringValues(values map[string]string) types.Map {
+	if len(values) == 0 {
+		return types.MapNull(types.StringType)
+	}
+
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	attrs := make(map[string]attr.Value, len(values))
+	for _, key := range keys {
+		attrs[key] = types.StringValue(values[key])
+	}
+
+	return types.MapValueMust(types.StringType, attrs)
+}
+
 func applyIntegration(state *model, in *client.Integration) {
 	state.ID = types.StringValue(in.ID)
 	state.ProjectID = types.StringValue(in.ProjectID)
@@ -175,7 +385,43 @@ func applyIntegration(state *model, in *client.Integration) {
 	for _, key := range keys {
 		values[key] = types.StringValue(in.Config[key])
 	}
-	state.Config = types.MapValueMust(types.StringType, values)
+	if len(values) == 0 {
+		state.Config = types.MapNull(types.StringType)
+	} else {
+		state.Config = types.MapValueMust(types.StringType, values)
+	}
+
+	if in.Type != "webhook" {
+		state.Webhook = webhookModel{
+			MethodDown:  types.StringNull(),
+			URLDown:     types.StringNull(),
+			BodyDown:    types.StringNull(),
+			HeadersDown: types.MapNull(types.StringType),
+			MethodUp:    types.StringNull(),
+			URLUp:       types.StringNull(),
+			BodyUp:      types.StringNull(),
+			HeadersUp:   types.MapNull(types.StringType),
+		}
+		return
+	}
+
+	state.Webhook = webhookModel{
+		MethodDown:  stringOrNull(in.Config["method_down"]),
+		URLDown:     stringOrNull(in.Config["url_down"]),
+		BodyDown:    stringOrNull(in.Config["body_down"]),
+		HeadersDown: mapStringValues(parseHeaderLines(in.Config["headers_down"])),
+		MethodUp:    stringOrNull(in.Config["method_up"]),
+		URLUp:       stringOrNull(in.Config["url_up"]),
+		BodyUp:      stringOrNull(in.Config["body_up"]),
+		HeadersUp:   mapStringValues(parseHeaderLines(in.Config["headers_up"])),
+	}
+}
+
+func stringOrNull(value string) types.String {
+	if strings.TrimSpace(value) == "" {
+		return types.StringNull()
+	}
+	return types.StringValue(value)
 }
 
 func (r *integrationResource) createIntegration(ctx context.Context, in client.Integration) (*client.Integration, error) {

--- a/internal/resources/integration/resource_test.go
+++ b/internal/resources/integration/resource_test.go
@@ -66,3 +66,15 @@ func TestParseHeaderLines(t *testing.T) {
 		t.Fatalf("unexpected X-Sample-Header: %q", headers["X-Sample-Header"])
 	}
 }
+
+func TestMapToStringsAllowsUnknownMap(t *testing.T) {
+	ctx := context.Background()
+
+	values, err := mapToStrings(ctx, types.MapUnknown(types.StringType))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(values) != 0 {
+		t.Fatalf("expected empty map, got %#v", values)
+	}
+}

--- a/internal/resources/integration/resource_test.go
+++ b/internal/resources/integration/resource_test.go
@@ -1,0 +1,68 @@
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestConfigFromModelWebhookBlock(t *testing.T) {
+	ctx := context.Background()
+
+	cfg, diags := configFromModel(ctx, model{
+		Type:   types.StringValue("webhook"),
+		Config: types.MapNull(types.StringType),
+		Webhook: webhookModel{
+			MethodDown: types.StringValue("POST"),
+			URLDown:    types.StringValue("https://example.com/down"),
+			BodyDown:   types.StringValue(`{"state":"down"}`),
+			HeadersDown: types.MapValueMust(types.StringType, map[string]attr.Value{
+				"X-Env":           types.StringValue("production"),
+				"X-Sample-Header": types.StringValue("$NAME has gone down"),
+			}),
+		},
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", diags)
+	}
+
+	if cfg["method_down"] != "POST" {
+		t.Fatalf("unexpected method_down: %q", cfg["method_down"])
+	}
+	if cfg["url_down"] != "https://example.com/down" {
+		t.Fatalf("unexpected url_down: %q", cfg["url_down"])
+	}
+	if cfg["headers_down"] != "X-Env: production\nX-Sample-Header: $NAME has gone down" {
+		t.Fatalf("unexpected headers_down: %q", cfg["headers_down"])
+	}
+}
+
+func TestConfigFromModelRejectsConflictingWebhookInputs(t *testing.T) {
+	ctx := context.Background()
+
+	_, diags := configFromModel(ctx, model{
+		Type: types.StringValue("webhook"),
+		Config: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"url_down": types.StringValue("https://example.com/down"),
+		}),
+		Webhook: webhookModel{
+			URLDown: types.StringValue("https://example.com/down"),
+		},
+	})
+	if !diags.HasError() {
+		t.Fatal("expected diagnostics for conflicting webhook inputs")
+	}
+}
+
+func TestParseHeaderLines(t *testing.T) {
+	headers := parseHeaderLines("X-Env: production\nX-Sample-Header: $NAME has gone down")
+
+	if headers["X-Env"] != "production" {
+		t.Fatalf("unexpected X-Env header: %q", headers["X-Env"])
+	}
+	if headers["X-Sample-Header"] != "$NAME has gone down" {
+		t.Fatalf("unexpected X-Sample-Header: %q", headers["X-Sample-Header"])
+	}
+}

--- a/templates/resources/integration.md.tmpl
+++ b/templates/resources/integration.md.tmpl
@@ -21,7 +21,8 @@ Import is supported using the following syntax:
 ## Notes
 
 - Use `type = "webhook"` for HTTP callbacks on up/down events.
-- Webhook integrations support the optional top-level `name` attribute.
-- Webhook request headers can be configured with `config.headers_down` and `config.headers_up` using newline-delimited `Header-Name: value` entries.
+- Webhook integrations support the optional top-level `name` attribute and the structured `webhook` block.
+- Webhook request headers can be configured with `webhook.headers_down` and `webhook.headers_up` as maps of header names to values.
+- The legacy `config` map is still accepted for webhook integrations, but the `webhook` block is the preferred interface.
 - Use `type = "email"` with `config.value` set to the destination email address.
 - Integrations become active for a check when their channel ID is referenced in `healthchecks_check.channels`.

--- a/templates/resources/integration.md.tmpl
+++ b/templates/resources/integration.md.tmpl
@@ -21,5 +21,7 @@ Import is supported using the following syntax:
 ## Notes
 
 - Use `type = "webhook"` for HTTP callbacks on up/down events.
+- Webhook integrations support the optional top-level `name` attribute.
+- Webhook request headers can be configured with `config.headers_down` and `config.headers_up` using newline-delimited `Header-Name: value` entries.
 - Use `type = "email"` with `config.value` set to the destination email address.
 - Integrations become active for a check when their channel ID is referenced in `healthchecks_check.channels`.


### PR DESCRIPTION
## Summary

- add a structured webhook block for webhook integrations
- support webhook headers as Terraform maps instead of multiline strings
- keep the legacy config map for backward compatibility
- add tests for webhook config translation and planning behavior
- update docs and examples to use the new webhook interface

## Validation

- env GOCACHE=$(pwd)/.gocache GOMODCACHE=$(pwd)/.gomodcache go test ./...
- tested against localhost Healthchecks at http://localhost:8000
