### PR TITLE
docs: clarify webhook integration configuration

### DIFF
--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -90,6 +90,8 @@ terraform import healthchecks_integration.webhook 1c580c01-499d-4832-a928-3a407d
 - Use `type = "webhook"` for HTTP callbacks on up/down events.
 - Webhook integrations support the optional top-level `name` attribute and the structured `webhook` block.
 - Webhook request headers can be configured with `webhook.headers_down` and `webhook.headers_up` as maps of header names to values.
+- Header maps are translated into the newline-delimited `Header-Name: value` format expected by the Healthchecks webhook form.
 - The legacy `config` map is still accepted for webhook integrations, but the `webhook` block is the preferred interface.
+- Use the legacy `config` map only when you need backward compatibility with older provider versions.
 - Use `type = "email"` with `config.value` set to the destination email address.
 - Integrations become active for a check when their channel ID is referenced in `healthchecks_check.channels`.

--- a/templates/resources/integration.md.tmpl
+++ b/templates/resources/integration.md.tmpl
@@ -23,6 +23,8 @@ Import is supported using the following syntax:
 - Use `type = "webhook"` for HTTP callbacks on up/down events.
 - Webhook integrations support the optional top-level `name` attribute and the structured `webhook` block.
 - Webhook request headers can be configured with `webhook.headers_down` and `webhook.headers_up` as maps of header names to values.
+- Header maps are translated into the newline-delimited `Header-Name: value` format expected by the Healthchecks webhook form.
 - The legacy `config` map is still accepted for webhook integrations, but the `webhook` block is the preferred interface.
+- Use the legacy `config` map only when you need backward compatibility with older provider versions.
 - Use `type = "email"` with `config.value` set to the destination email address.
 - Integrations become active for a check when their channel ID is referenced in `healthchecks_check.channels`.


### PR DESCRIPTION
## Summary

- clarify how webhook header maps are translated for Healthchecks
- explain when to use the legacy config map vs the structured webhook block
- keep the provider integration docs aligned with the released interface

## Validation

- docs-only change
